### PR TITLE
remove zero-width-space (U+200B) chars from appdata

### DIFF
--- a/data/com.github.luizaugustomm.tomato.appdata.xml
+++ b/data/com.github.luizaugustomm.tomato.appdata.xml
@@ -66,7 +66,7 @@
          <li>Bug fixes</li>
        </ul>
      ⁠</description>
-    ​ </release>
+     </release>
 
       <release version="1.2.8" urgency="medium" date="2017-04-29">
          ⁠<description>
@@ -76,7 +76,7 @@
              <li>Fixed minor bugs</li>
            </ul>
          ⁠</description>
-     ​ </release>
+      </release>
 
       <release version="1.2.7" urgency="medium" date="2017-04-11">
          ⁠<description>
@@ -84,7 +84,7 @@
              <li>Fixed minor bugs</li>
            </ul>
          ⁠</description>
-     ​ </release>
+      </release>
 
       <release version="1.2.6" urgency="medium" date="2017-04-10">
          ⁠<description>
@@ -92,7 +92,7 @@
              <li>Fixed minor bugs</li>
            </ul>
          ⁠</description>
-     ​ </release>
+      </release>
 
       <release version="1.2.5" urgency="medium" date="2017-04-08"/>
 
@@ -103,7 +103,7 @@
              <li>Fixed minor bugs</li>
            </ul>
          ⁠</description>
-     ​ </release>
+      </release>
 
       <release version="1.2.3" urgency="medium" date="2017-04-06"/>
 
@@ -115,6 +115,6 @@
              <li>Integration with AppCenter</li>
            </ul>
          ⁠</description>
-     ​ </release>
+      </release>
   </releases>
 </component>


### PR DESCRIPTION
This removes some U+200B (Unicode zero-width space) characters from the appdata file, because those characters break libappstream-glib.