### PR TITLE
Add dependencies install instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ If you want to hack on and build Tomato yourself, you'll need the following depe
 - libcanberra
 - libunity
 
+Install the dependencies
+
+```shell
+sudo apt install elementary-sdk libcanberra-dev libunity-dev
+```
+
 Create a `build` directory
 
 ```shell


### PR DESCRIPTION
Looks like just installing the `elementary-sdk` is not enough to be able to build the app and it's causing some confusion (e.g: https://github.com/tomatoers/tomato/issues/62). This PR add instructions about how install the dependencies to the README.